### PR TITLE
New static method: VSLUtil.tagExists

### DIFF
--- a/varnishapi.py
+++ b/varnishapi.py
@@ -243,6 +243,10 @@ class VSLUtil:
     def tag2VarName(self, tag, data):
         return self.tag2Var(tag, data)['key']
     
+    @classmethod
+    def tagExists(cls, tag):
+        return cls.__tags.has_key(tag)
+
     __tags = {
         'Debug'          : '',
         'Error'          : '',


### PR DESCRIPTION
This patch introduces a new static method called tagExists allowing to
check whether a certain VSL tag exists or not.